### PR TITLE
Specify type for suppressing byte-compile warnings

### DIFF
--- a/pnpm-mode.el
+++ b/pnpm-mode.el
@@ -176,7 +176,8 @@ Optional argument COMINT ."
 
 (defcustom pnpm-mode-command-prefix "C-c n"
   "Prefix for variable `pnpm-mode'."
-  :group 'pnpm-mode)
+  :group 'pnpm-mode
+  :type 'string)
 
 (defvar pnpm-mode-command-keymap
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
Fix following warnings

```
pnpm-mode.el:177:1:Warning: defcustom for ‘pnpm-mode-command-prefix’ fails to
    specify type
pnpm-mode.el:177:1:Warning: defcustom for ‘pnpm-mode-command-prefix’ fails to
    specify type
```